### PR TITLE
fix: compile errors related to typings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 app/js
-app/typings
+app/typings/*
+!app/typings/tsd.d.ts
 example-app/js/*
 example-app/node_modules/*
 example-app/typings/*

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ THIS IS A WORK IN PROGRESS
 
 1. Clone this repository: `git clone git://github.com/rangle/batarangle`
 2. Run `npm install`
-3. Run `gulp build` (Note: there are some tsd related error during build, ignore those for now)
+3. Run `gulp build`
 4. Navigate to chrome://extensions and enable Developer Mode.
 5. Choose "Load unpacked extension"
 6. In the dialog, open the directory you just cloned.

--- a/app/typings/tsd.d.ts
+++ b/app/typings/tsd.d.ts
@@ -1,0 +1,1 @@
+/// <reference path="../../node_modules/immutable/dist/immutable.d.ts" />

--- a/package.json
+++ b/package.json
@@ -17,9 +17,10 @@
   },
   "homepage": "https://github.com/rangle/batarangle",
   "scripts": {
-    "postinstall": "tsd install && tsd link"
+    "postinstall": "tsd install"
   },
   "dependencies": {
+    "angular2": "^2.0.0-alpha.37",
     "crypto": "0.0.3",
     "immutable": "^3.7.5",
     "rx": "^4.0.0",

--- a/tsd.json
+++ b/tsd.json
@@ -12,7 +12,22 @@
       "commit": "32029fcb4e1a3ef8968711b545d77b584435729d"
     },
     "es6-promise/es6-promise.d.ts": {
-      "commit": "32029fcb4e1a3ef8968711b545d77b584435729d"
+      "commit": "ffceea9dd124d277c4597c7bd12930666ec074c5"
+    },
+    "rx/rx.d.ts": {
+      "commit": "ffceea9dd124d277c4597c7bd12930666ec074c5"
+    },
+    "angular2/angular2.d.ts": {
+      "commit": "ffceea9dd124d277c4597c7bd12930666ec074c5"
+    },
+    "rx/rx-lite.d.ts": {
+      "commit": "ffceea9dd124d277c4597c7bd12930666ec074c5"
+    },
+    "angular2/http.d.ts": {
+      "commit": "ffceea9dd124d277c4597c7bd12930666ec074c5"
+    },
+    "angular2/router.d.ts": {
+      "commit": "ffceea9dd124d277c4597c7bd12930666ec074c5"
     }
   }
 }


### PR DESCRIPTION
 - install all the necessary typings from tsd so as internal typing references work.
 - hardcode immutable in tsd.d.ts (no available via tsd)
 - add angular2 as dependency in package.json (was ommited on last commit)
 - modify .gitigore to exclude tsd.d.ts

This PR will resolve #23 