### PR TITLE
feat(adapters): Use tagnames when generic comps

### DIFF
--- a/app/ts/batarangle/backend/adapters/angular2.ts
+++ b/app/ts/batarangle/backend/adapters/angular2.ts
@@ -282,7 +282,12 @@ export class Angular2Adapter extends BaseAdapter {
   _getComponentName(compEl: DebugElement): string {
     const constructor =  <any>this._getComponentInstance(compEl)
                                   .constructor
-    return constructor.name;
+    const constructorName = constructor.name;
+
+    // Cover components not backed by a custom class.
+    return constructorName !== 'Object' ?
+           constructorName :
+           this._getComponentRef(compEl).tagName;
   }
   
   _isSerializable(val: any) {


### PR DESCRIPTION
In cases where the component isn't backed by a framework or user-defined
class, we'll use the tagname for display. This prevents showing
undistinguishable "Object" annotations for the component view.

NOTE: In HTML documents, the casing of tag/node names isn't preserved
and is uppercased instead. If this isn't desirable, the front-end should
format the display as it sees fit.