### PR TITLE
fix(adapters/controllers): track changes to views

### DIFF
--- a/app/ts/batarangle/backend/adapters/base.ts
+++ b/app/ts/batarangle/backend/adapters/base.ts
@@ -35,7 +35,7 @@ import { AdapterEventType as EventType } from './event_types';
 
 export interface AdapterEvent {
   type: string,   // AdapterEventType
-  node: Node,
+  node?: Node,
 }
 
 export interface TreeNode {
@@ -83,12 +83,12 @@ export class BaseAdapter {
   }
 
   removeRoot(el: Element): void {
-    const childEvt: AdapterEvent = {
+    const rootEvt: AdapterEvent = {
       type: EventType.REMOVE,
       node: el,
     };
 
-    this._stream.onNext(childEvt);
+    this._stream.onNext(rootEvt);
   }
 
   removeChild(el: Element): void {
@@ -98,6 +98,14 @@ export class BaseAdapter {
     };
 
     this._stream.onNext(childEvt);
+  }
+
+  reset(): void {
+    const evt: AdapterEvent = {
+      type: EventType.CLEAR,
+    }
+
+    this._stream.onNext(evt);
   }
 
   subscribe(next?: Function, err?: Function, done?: Function): void {

--- a/app/ts/batarangle/backend/adapters/event_types.ts
+++ b/app/ts/batarangle/backend/adapters/event_types.ts
@@ -15,6 +15,7 @@
  * - 'add': A new child component has been added to the view.
  * - 'change': A component in the view has changed.
  * - 'remove': A component has been removed from the view.
+ * - 'clear': Reset component view.
  */
 
 // window.postMessage({ type: "BATARANGLE_INSPECTED_APP", text: "Loaded adapters/event_types.js" }, "*");
@@ -24,6 +25,7 @@ enum _AdapterEventType {
   ADD,
   CHANGE,
   REMOVE,
+  CLEAR,
 }
 
 // TSFIXME(bertrandk): There doesn't seem to be much better ways of creating
@@ -55,5 +57,9 @@ export class AdapterEventType {
 
   static get REMOVE(): string {
     return AdapterEventType._get('REMOVE');
+  }
+
+  static get CLEAR(): string {
+    return AdapterEventType._get('CLEAR');
   }
 }

--- a/app/ts/batarangle/backend/controllers/dom.ts
+++ b/app/ts/batarangle/backend/controllers/dom.ts
@@ -44,7 +44,7 @@ export class DomController extends BaseController {
     this.model = [];
     this.adapter = adapter;
     this.channel = channel;
-    
+
     //channel.sendMessage({ text: 'TEST MESSAGE' });
     //window.postMessage({ type: "BATARANGLE_INSPECTED_APP", message: 'DomController constructor' }, "*");
   }
@@ -71,6 +71,9 @@ export class DomController extends BaseController {
       case EventType.REMOVE:
         this._handleRemovals(evt.node);
         break;
+      case EventType.CLEAR:
+        this._handleReset();
+        break;
       default:
         throw Error('Unknown adapter event.');
     }
@@ -91,12 +94,9 @@ export class DomController extends BaseController {
     const idxParts = childNode.id.split('.');
     const rootIdx = idxParts[0];
     const childIdx = idxParts[1];
-    
-    // fixed??? No
-    if (this.model[rootIdx] ) {
-      this.model[rootIdx].children = this.model[rootIdx].children || [];
-      this.model[rootIdx].children[childIdx] = childNode;
-    }
+
+    this.model[rootIdx].children = this.model[rootIdx].children || [];
+    this.model[rootIdx].children[childIdx] = childNode;
   }
 
   _handleComponentChanges(node: Node) {
@@ -131,6 +131,10 @@ export class DomController extends BaseController {
       this.model.splice(rootIdx, 1);
     }
 
-    this.model[rootIdx].children.splice(childIdx, 1); // fix typo childrens
+    this.model[rootIdx].children.splice(childIdx, 1);
+  }
+
+  _handleReset() {
+    this.model = [];
   }
 }


### PR DESCRIPTION
We're adding a new adapter event here: 'clear'. For the time being, rather
than attempt to keep track of internal views at the DOM layer, we'll be
clearing and rebuilding the tree model whenever a change is observed.

This reduces a lot of the complexity involved in reconciling the view
listener's world and that of the resultant DOM.

I've also done some code cleanup.