### PR TITLE
Add TS sourcemaps support

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,6 +5,7 @@ var gulp = require('gulp');
 var rename = require('gulp-rename');
 var ts = require('gulp-typescript');
 var tslint = require('gulp-tslint');
+var sourcemaps = require('gulp-sourcemaps');
 
 gulp.task('default', ['build']);
 
@@ -59,12 +60,15 @@ gulp.task('compile', ['lint'], function (done) {
     typescript: require('typescript')
   });
 
-  return tsProject.src()
-    .pipe(ts(tsProject))
-    .js
+  var tsResult = tsProject.src()
+    .pipe(sourcemaps.init( { debug: true } ))
+    .pipe(ts(tsProject));
+    
+  return tsResult.js
     .pipe(rename(function (path) {
       path.dirname = path.dirname.replace('app/ts', 'js');
     }))
+    .pipe(sourcemaps.write( { sourceRoot: '/' } ))
     .pipe(gulp.dest('app'));
 });
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "del": "^2.0.2",
     "gulp": "^3.9.0",
     "gulp-rename": "^1.2.2",
+    "gulp-sourcemaps": "^1.6.0",
     "gulp-tslint": "^3.2.0",
     "gulp-typescript": "^2.9.0",
     "tsd": "^0.6.4",


### PR DESCRIPTION
Adding source maps support seems to be as simple as generating them during the build process. This is identical to what we do when developing pure web applications using TS.

Tested with @winkerVSbecks on our injected script, content script and the dev tools page and stepped through the TS code.

This PR is related to issue #34 