### PR TITLE
update rxjs import - fix #86

### DIFF
--- a/backend/adapters/base.ts
+++ b/backend/adapters/base.ts
@@ -27,7 +27,7 @@
  * (../controller/dom.ts).
  */
 
-import {Subject} from '@reactivex/rxjs';
+import {Subject} from 'rxjs';
 import { AdapterEventType as EventType } from './event_types';
 
 export interface AdapterEvent {

--- a/frontend/dispatcher/dispatcher.ts
+++ b/frontend/dispatcher/dispatcher.ts
@@ -1,4 +1,4 @@
-import {Subject} from '@reactivex/rxjs';
+import {Subject} from 'rxjs';
 
 export class Dispatcher {
 

--- a/frontend/stores/abstract-store.ts
+++ b/frontend/stores/abstract-store.ts
@@ -1,4 +1,4 @@
-import {ReplaySubject} from '@reactivex/rxjs';
+import {ReplaySubject} from 'rxjs';
 
 export abstract class AbstractStore {
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "webpack --config webpack.test.config.js && browserify build/test.js | tape-run | tap-spec"
   },
   "dependencies": {
-    "@reactivex/rxjs": "^5.0.0-beta.0",
+    "rxjs": "^5.0.0-beta.0",
     "angular2": "^2.0.0-beta.0",
     "basscss": "^7.0.4",
     "browserify": "^12.0.1",


### PR DESCRIPTION
import RxJS modules from `rxjs` instead of `@reactive/rxjs` to match angular core. This fixes #86 - see issue for more details. 

Note that the example app has not been updated to beta-0 yet 