### PR TITLE
add script to package the extension to a .crx format for unofficial distributions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ typings/*
 !typings/tsd.d.ts
 example-apps/todo-mvc-example/jspm_packages/*
 example-apps/todo-mvc-example/typings/*
+
+key.pem
+*.crx

--- a/crxmake.sh
+++ b/crxmake.sh
@@ -1,0 +1,57 @@
+#!/bin/bash -e
+#
+# Package batarangle into crx format Chrome extension
+# (This will not be needed for official distribution)
+# Based on https://developer.chrome.com/extensions/crx#scripts
+
+dir="temp"
+key="key.pem"
+name="batarangle-packaged"
+files="build frontend images node_modules index.html manifest.json"
+
+crx="$name.crx"
+pub="$name.pub"
+sig="$name.sig"
+zip="$name.zip"
+trap 'rm -f "$pub" "$sig" "$zip"' EXIT
+
+# copy all the files we need
+rm -rf $dir
+mkdir $dir
+cp -R $files $dir/
+
+# generate private key key.pem if it doesn't exist already
+if [ ! -f $key ]; then
+  echo "$key doesn't exist."
+  openssl genrsa -out key.pem 1024
+fi
+
+# zip up the crx dir
+cwd=$(pwd -P)
+(cd "$dir" && zip -qr -9 -X "$cwd/$zip" .)
+
+# signature
+openssl sha1 -sha1 -binary -sign "$key" < "$zip" > "$sig"
+
+# public key
+openssl rsa -pubout -outform DER < "$key" > "$pub" 2>/dev/null
+
+byte_swap () {
+  # Take "abcdefgh" and return it as "ghefcdab"
+  echo "${1:6:2}${1:4:2}${1:2:2}${1:0:2}"
+}
+
+crmagic_hex="4372 3234" # Cr24
+version_hex="0200 0000" # 2
+pub_len_hex=$(byte_swap $(printf '%08x\n' $(ls -l "$pub" | awk '{print $5}')))
+sig_len_hex=$(byte_swap $(printf '%08x\n' $(ls -l "$sig" | awk '{print $5}')))
+(
+  echo "$crmagic_hex $version_hex $pub_len_hex $sig_len_hex" | xxd -r -p
+  cat "$pub" "$sig" "$zip"
+) > "$crx"
+
+echo "Wrote $crx"
+
+# clean up
+rm -rf $dir
+echo "Fin."

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Angular 2.0 Batarangle",
-  "version": "0.1.0",
+  "version": "0.0.2",
   "description": "Extends the Developer Tools, adding tools for debugging and profiling Angular 2.0 applications.",
   "permissions": [
     "tabs",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "tsd-update": "npm run remove-tsd-loader-typings && tsd reinstall --overwrite",
     "postinstall": "npm run tsd-update && tsd install && tsd link",
     "start": "rimraf build && webpack --watch",
-    "test": "webpack --config webpack.test.config.js && browserify build/test.js | tape-run | tap-spec"
+    "test": "webpack --config webpack.test.config.js && browserify build/test.js | tape-run | tap-spec",
+    "prepack": "npm test", 
+    "pack": "./crxmake.sh"
   },
   "dependencies": {
     "rxjs": "^5.0.0-beta.0",


### PR DESCRIPTION
 - run `npm run pack` to generate `batarangle-packaged.crx' which then can be installed in Chrome directly
 - update manifest.json to match the version # in package.json