### PR TITLE
chore: make batarangle work with apps built in ng2-beta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ example-apps/todo-mvc-example/typings/*
 
 key.pem
 *.crx
+.vscode/

--- a/backend/adapters/base.ts
+++ b/backend/adapters/base.ts
@@ -52,7 +52,7 @@ export interface TreeNode {
 export abstract class BaseAdapter {
   private _stream: Subject<any> = new Subject();
 
-  addRoot(rootEl: Element): void {
+  addRoot(rootEl: any): void {
     const rootEvt: AdapterEvent = {
       type: EventType.ROOT,
       node: rootEl
@@ -61,7 +61,7 @@ export abstract class BaseAdapter {
     this._stream.next(rootEvt);
   }
 
-  addChild(childEl: Element): void {
+  addChild(childEl: any): void {
     const childEvt: AdapterEvent = {
       type: EventType.ADD,
       node: childEl
@@ -70,7 +70,7 @@ export abstract class BaseAdapter {
     this._stream.next(childEvt);
   }
 
-  changeComponent(el: Element): void {
+  changeComponent(el: any): void {
     const childEvt: AdapterEvent = {
       type: EventType.CHANGE,
       node: el
@@ -79,7 +79,7 @@ export abstract class BaseAdapter {
     this._stream.next(childEvt);
   }
 
-  removeRoot(el: Element): void {
+  removeRoot(el: any): void {
     const rootEvt: AdapterEvent = {
       type: EventType.REMOVE,
       node: el
@@ -88,7 +88,7 @@ export abstract class BaseAdapter {
     this._stream.next(rootEvt);
   }
 
-  removeChild(el: Element): void {
+  removeChild(el: any): void {
     const childEvt: AdapterEvent = {
       type: EventType.REMOVE,
       node: el
@@ -115,7 +115,7 @@ export abstract class BaseAdapter {
 
   abstract setup(): void;
 
-  abstract serializeComponent(el: Element, event: string): TreeNode;
+  abstract serializeComponent(el: any, event: string): TreeNode;
 
   abstract cleanup(): void;
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "rxjs": "^5.0.0-beta.0",
-    "angular2": "^2.0.0-beta.0",
+    "angular2": "^2.0.0-beta.1",
     "basscss": "^7.0.4",
     "browserify": "^12.0.1",
     "crypto": "0.0.3",


### PR DESCRIPTION
- change the way batarangle-id is set for structural directives since their templates are now stamped out as comment nodes instead of script tags
- upgrade to Angular2 beta-.1

This should fix #89 and #92.