### PR TITLE
fix null exception

### DIFF
--- a/backend/adapters/angular2.ts
+++ b/backend/adapters/angular2.ts
@@ -121,7 +121,7 @@ export class Angular2Adapter extends BaseAdapter {
     // batarangle-id above it.
     if (nativeElement.nodeType === Node.COMMENT_NODE) {
       const commentNode = document.createComment(`{"batarangle-id": "${idx}"}`);
-      if (!nativeElement.previousSibling.isEqualNode(commentNode)) {
+      if (nativeElement.previousSibling === null || !nativeElement.previousSibling.isEqualNode(commentNode)) {
         nativeElement.parentNode.insertBefore(commentNode, nativeElement);
       }
     } else {


### PR DESCRIPTION
When `previousSibling` is called on the first child that is _not_ following a line break in source code, it actually returns `null` instead of a text node. Quick fix to take that into account. 

_Should_ resolve #121 