### PR TITLE
chore: upgrade angular2 version to beta.9

### DIFF
--- a/example-apps/kitchen-sink-example/package.json
+++ b/example-apps/kitchen-sink-example/package.json
@@ -2,17 +2,17 @@
   "name": "kitchen-sink-example",
   "scripts": {
     "postinstall": "npm run typings",
-    "typings": "rimraf typings && tsd install && tsd link",
+    "typings": "rimraf typings && typings install",
     "start": "webpack-dev-server --display-error-details --display-cached"
   },
-  "dependencies": {},
-  "devDependencies": {
-    "angular2": "2.0.0-beta.8",
+  "devDependencies": {},
+  "dependencies": {
+    "angular2": "2.0.0-beta.9",
+    "rxjs": "5.0.0-beta.0",
     "es6-promise": "^3.0.2",
     "es6-shim": "^0.33.3",
     "immutable": "^3.7.6",
     "reflect-metadata": "0.1.2",
-    "rxjs": "5.0.0-beta.2",
     "zone.js": "^0.5.15",
     "css-loader": "^0.21.0",
     "file-loader": "^0.8.4",
@@ -21,9 +21,9 @@
     "rimraf": "^2.4.3",
     "style-loader": "^0.13.0",
     "ts-loader": "^0.7.2",
-    "tsd": "^0.6.5",
     "tslint-loader": "^1.0.2",
     "typescript": "^1.7.3",
+    "typings": "^0.7.7",
     "url-loader": "^0.5.6",
     "webpack": "^1.12.9",
     "webpack-dev-server": "^1.14.0"

--- a/example-apps/kitchen-sink-example/tsconfig.json
+++ b/example-apps/kitchen-sink-example/tsconfig.json
@@ -9,6 +9,8 @@
     "noImplicitAny": false
   },
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "typings/main",
+    "typings/main.d.ts"
   ]
 }

--- a/example-apps/kitchen-sink-example/tsd.json
+++ b/example-apps/kitchen-sink-example/tsd.json
@@ -1,8 +1,0 @@
-{
-  "version": "v4",
-  "repo": "borisyankov/DefinitelyTyped",
-  "ref": "master",
-  "path": "typings",
-  "bundle": "typings/tsd.d.ts",
-  "installed": {}
-}

--- a/example-apps/kitchen-sink-example/typings.json
+++ b/example-apps/kitchen-sink-example/typings.json
@@ -1,0 +1,13 @@
+{
+  "name": "kitchen-sink-example",
+  "ambientDependencies": {
+    "es6-shim": "github:DefinitelyTyped/DefinitelyTyped/es6-shim/es6-shim.d.ts#4de74cb527395c13ba20b438c3a7a419ad931f1c",
+    "ng2": "github:gdi2290/typings-ng2/ng2.d.ts#32998ff5584c0eab0cd9dc7704abb1c5c450701c",
+    "node": "github:DefinitelyTyped/DefinitelyTyped/node/node.d.ts#263705d313346e093d95cb62cef6fed848e46978",
+    "webpack": "github:DefinitelyTyped/DefinitelyTyped/webpack/webpack.d.ts#95c02169ba8fa58ac1092422efbd2e3174a206f4",
+    "zone.js": "github:DefinitelyTyped/DefinitelyTyped/zone.js/zone.js.d.ts#c393f8974d44840a6c9cc6d5b5c0188a8f05143d"
+  },
+  "dependencies": {
+    "es6-promise": "github:typed-typings/npm-es6-promise#fb04188767acfec1defd054fc8024fafa5cd4de7"
+  }
+}

--- a/example-apps/kitchen-sink-example/typings/tsd.d.ts
+++ b/example-apps/kitchen-sink-example/typings/tsd.d.ts
@@ -1,4 +1,0 @@
-/// <reference path="../node_modules/definition-header/dist/index.d.ts" />
-/// <reference path="../node_modules/immutable/dist/immutable.d.ts" />
-/// <reference path="../node_modules/reflect-metadata/reflect-metadata.d.ts" />
-/// <reference path="../node_modules/angular2/typings/browser.d.ts"/>

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "pack": "./crxmake.sh"
   },
   "dependencies": {
-    "angular2": "2.0.0-beta.8",
+    "angular2": "2.0.0-beta.9",
     "basscss": "^7.0.4",
     "browserify": "^12.0.1",
     "crypto": "0.0.3",


### PR DESCRIPTION
 - upgrade both batarangle and kitchen sink app to angular2@beta.9
 - deprecate tsd and switch to typings