### PR TITLE
chore: upgrade to beta.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,15 +24,16 @@
     "build": "npm run webpack --colors --display-error-details --display-cached",
     "webpack": "webpack",
     "clean": "rimraf node_modules typings",
-    "postinstall": "typings install",
+    "postinstall": "rimraf typings && typings install",
     "start": "rimraf build && webpack --watch",
     "test": "webpack --config webpack.test.config.js && cat build/test.js | tape-run | tap-spec",
     "prepack": "npm run build",
     "pack": "./crxmake.sh"
   },
   "dependencies": {
-    "angular2": "2.0.0-beta.9",
+    "angular2": "2.0.0-beta.10",
     "basscss": "^7.0.4",
+    "core-js": "^2.2.0",
     "crypto": "0.0.3",
     "es6-promise": "^3.0.2",
     "es6-shim": "^0.33.6",
@@ -41,7 +42,7 @@
     "json-formatter-js": "^0.3.0",
     "reflect-metadata": "0.1.2",
     "rxjs": "5.0.0-beta.2",
-    "zone.js": "0.5.15"
+    "zone.js": "0.6.4"
   },
   "devDependencies": {
     "autoprefixer": "^6.3.1",

--- a/src/frontend/components/info-panel/info-panel.ts
+++ b/src/frontend/components/info-panel/info-panel.ts
@@ -1,4 +1,4 @@
-import {Component, View, ElementRef, Inject, NgZone} from 'angular2/core';
+import {Component, ElementRef, Inject, NgZone} from 'angular2/core';
 import {NgIf} from 'angular2/common';
 import * as Rx from 'rxjs';
 import {ComponentDataStore}
@@ -11,9 +11,7 @@ import ComponentInfo from '../component-info/component-info';
 import DependentComponents from '../dependent-components/dependent-components';
 
 @Component({
-  selector: 'bt-info-panel'
-})
-@View({
+  selector: 'bt-info-panel',
   templateUrl: '/src/frontend/components/info-panel/info-panel.html',
   directives: [NgIf, TabMenu, ComponentInfo, DependentComponents]
 })

--- a/src/frontend/components/node-item/node-item.ts
+++ b/src/frontend/components/node-item/node-item.ts
@@ -1,4 +1,4 @@
-import {Component, View, Inject, NgZone} from 'angular2/core';
+import {Component, Inject, NgZone} from 'angular2/core';
 import {NgIf, NgFor, NgStyle} from 'angular2/common';
 import * as Rx from 'rxjs';
 import {ComponentDataStore}
@@ -9,9 +9,7 @@ import {UserActionType}
 
 @Component({
   selector: 'bt-node-item',
-  properties: ['node: node', 'collapsed: collapsed']
-})
-@View({
+  properties: ['node: node', 'collapsed: collapsed'],
   templateUrl: 'src/frontend/components/node-item/node-item.html',
   directives: [NgIf, NgFor, NodeItem, NgStyle]
 })

--- a/src/frontend/components/tree-view/tree-view.ts
+++ b/src/frontend/components/tree-view/tree-view.ts
@@ -1,4 +1,4 @@
-import {Component, View, Inject, NgZone} from 'angular2/core';
+import {Component, Inject, NgZone} from 'angular2/core';
 import {NgFor} from 'angular2/common';
 import {NodeItem} from '../node-item/node-item';
 import {InfoPanel} from '../info-panel/info-panel';
@@ -10,9 +10,7 @@ import {UserActionType}
 
 @Component({
   selector: 'bt-tree-view',
-  properties: ['tree: tree']
-})
-@View({
+  properties: ['tree: tree'],
   templateUrl: 'src/frontend/components/tree-view/tree-view.html',
   directives: [NgFor, NodeItem, InfoPanel]
 })

--- a/src/frontend/frontend.ts
+++ b/src/frontend/frontend.ts
@@ -1,4 +1,4 @@
-import {Component, View, Inject, bind, NgZone} from 'angular2/core';
+import {Component, Inject, bind, NgZone} from 'angular2/core';
 import {bootstrap} from 'angular2/bootstrap';
 
 import {Dispatcher} from './dispatcher/dispatcher';
@@ -21,9 +21,7 @@ import * as Rx from 'rxjs';
 const BASE_STYLES = require('!style!css!postcss!../styles/app.css');
 
 @Component({
-  selector: 'bt-app'
-})
-@View({
+  selector: 'bt-app',
   directives: [TreeView, InfoPanel],
   template: `
     <div class="clearfix">

--- a/typings.json
+++ b/typings.json
@@ -6,11 +6,9 @@
     "es6-shim": "github:DefinitelyTyped/DefinitelyTyped/es6-shim/es6-shim.d.ts#4de74cb527395c13ba20b438c3a7a419ad931f1c",
     "filesystem": "github:DefinitelyTyped/DefinitelyTyped/filesystem/filesystem.d.ts#62eedc3121a5e28c50473d2e4a9cefbcb9c3957f",
     "filewriter": "github:DefinitelyTyped/DefinitelyTyped/filewriter/filewriter.d.ts#62eedc3121a5e28c50473d2e4a9cefbcb9c3957f",
-    "ng2": "github:gdi2290/typings-ng2/ng2.d.ts#32998ff5584c0eab0cd9dc7704abb1c5c450701c",
     "node": "github:DefinitelyTyped/DefinitelyTyped/node/node.d.ts#263705d313346e093d95cb62cef6fed848e46978",
     "tape": "github:DefinitelyTyped/DefinitelyTyped/tape/tape.d.ts#c2c22c3b953fe9730d4802022d5e0d18d083909e",
-    "webpack": "github:DefinitelyTyped/DefinitelyTyped/webpack/webpack.d.ts#95c02169ba8fa58ac1092422efbd2e3174a206f4",
-    "zone.js": "github:DefinitelyTyped/DefinitelyTyped/zone.js/zone.js.d.ts#c393f8974d44840a6c9cc6d5b5c0188a8f05143d"
+    "webpack": "github:DefinitelyTyped/DefinitelyTyped/webpack/webpack.d.ts#95c02169ba8fa58ac1092422efbd2e3174a206f4"
   },
   "dependencies": {
     "es6-promise": "github:typed-typings/npm-es6-promise#fb04188767acfec1defd054fc8024fafa5cd4de7"

--- a/webpack.test.config.js
+++ b/webpack.test.config.js
@@ -4,10 +4,7 @@ var path = require('path');
 module.exports = {
   entry: {
     'test': [
-      'rxjs',
-      'zone.js/dist/zone-microtask',
-      'zone.js/dist/long-stack-trace-zone',
-      'reflect-metadata',
+      path.join(__dirname, 'webpack.vendor.ts'),
       path.join(__dirname, 'webpack.test.bootstrap.ts')
     ]
   },

--- a/webpack.vendor.ts
+++ b/webpack.vendor.ts
@@ -1,9 +1,11 @@
+/// <reference path="node_modules/zone.js/dist/zone.js.d.ts" />
+
 // Polyfills
-import 'es6-shim';
-import 'es6-promise';
 import 'reflect-metadata';
-import 'zone.js/dist/zone-microtask';
-import 'zone.js/dist/long-stack-trace-zone'; // remove this for prod
+import 'core-js';
+// import 'zone.js';
+// ng2 beta-10 issue with zone.js
+// track https://github.com/angular/angular/issues/7660
 
 // Angular 2
 import 'angular2/platform/browser';


### PR DESCRIPTION
 - upgrade angular2@2.0.0-beta.10
 - upgrade zone.js@0.6.4
 - prefer core-js polyfill over es6-shim and/or es6-promise
 - remove typings that are not needed
 - remove all @View annotations
 - workaround for temporary zone.js issue that surfaced with the beta10 upgrade (see https://github.com/angular/angular/issues/7660)
 - have webpack.test.config use the same vendor file for convenience

There are some known issues with beta 10, namely https://github.com/angular/angular/issues/7656 that cause the following build error:
```
ERROR in .../batarangle/node_modules/angular2/src/common/directives/ng_plural.d.ts
(2,10): error TS2305: Module '".../batarangle/node_modules/angular2/src/common/directives/ng_switch"' has no exported member 'SwitchView'.
```
Currently no workaround but it's not a blocking error.