### PR TITLE
Bugfix/ip 238 angular2 check

### DIFF
--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -1,5 +1,3 @@
-import {DomController} from './controllers/dom';
-import {Angular2Adapter} from './adapters/angular2';
 import Highlighter from './utils/highlighter';
 import ParseData from '../frontend/utils/parse-data';
 
@@ -14,10 +12,20 @@ let channel = {
   }
 };
 
-let adapter = new Angular2Adapter();
-let dom = new DomController(adapter, channel);
-dom.hookIntoBackend();
-adapter.setup();
+let adapter, dom;
+
+if (window.hasOwnProperty('ng')) {
+  const {Angular2Adapter} = require('./adapters/angular2');
+  const {DomController} = require('./controllers/dom');
+
+  adapter = new Angular2Adapter();
+  dom = new DomController(adapter, channel);
+}
+
+if(adapter && dom) {
+  dom.hookIntoBackend();
+  adapter.setup();
+}  
 
 
 window.addEventListener('message', function(event) {

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -14,19 +14,20 @@ let channel = {
 
 let adapter, dom;
 
+/*
+ * We only hook batarangle to the DOM if "ng" is a variable
+ * on the window. This signifies that the app is likely to be Angular 2
+ */
 if (window.hasOwnProperty('ng')) {
   const {Angular2Adapter} = require('./adapters/angular2');
   const {DomController} = require('./controllers/dom');
 
   adapter = new Angular2Adapter();
   dom = new DomController(adapter, channel);
-}
 
-if(adapter && dom) {
   dom.hookIntoBackend();
   adapter.setup();
-}  
-
+}
 
 window.addEventListener('message', function(event) {
   // We only accept messages from ourselves


### PR DESCRIPTION
Concerning #238 I switched out some imports to require statements for conditional loading. You check if your window object has the **ng** attribute. 

If so you're probably running Angular2 so you can start your adapter and hook into the DOM. 

I don't feel it's the cleanest fix in the world, since I prefer ES6 imports, but for the sake of low coupling I felt that backend.ts should be responsible for only loading **IF** ```window.ng``` is defined.